### PR TITLE
feat: enable snitches individually

### DIFF
--- a/README.org
+++ b/README.org
@@ -8,6 +8,12 @@ Stupidly simple and non-configurable Neovim plugin that informs you about the fo
 
 Only buffers whose type (~:help buftype~) is either empty (normal files) or ~acwrite~ will be affected.
 
+The default behavior is to alert on all three conditions. If necessary, snitches may be individually disabled using the following buffer-local flags:
+
+- ~b:Snitch_disable_lines_excess~
+- ~b:Snitch_disable_trailing_whitespace~
+- ~b:Snitch_disable_wrong_indentation~
+
 ** Non goals
 
 - Configurability. There's only one valid opinion here: text must follow the law, so the plugin should automatically work, always. If you don't care about long lines in a certain filetype, set the ~textwidth~ option to ~0~ in a personal filetype plugin (~:h ftplugin~) or with a filetype autocommand (~:h FileType~). In the same way, you can set [[https://tedlogan.com/techblog3.html][whatever rules you want for indentation]].

--- a/plugin/snitch.fnl
+++ b/plugin/snitch.fnl
@@ -8,13 +8,14 @@
 		(procedure)))
 
 (fn highlight-lines-excess []
-	(when (not= w.lines_excess_match_id nil)
-		(pcall #(call.matchdelete w.lines_excess_match_id)))
-	(execute-if-writable-buffer (fn []
-		(local textwidth (opt.textwidth:get))
-		(when (> textwidth 0)
-			(local regex (string.format "\\%%>%iv.\\+" textwidth))
-			(set w.lines_excess_match_id (call.matchadd :ColorColumn regex -1))))))
+	(when (not vim.b.Snitch_disable_lines_excess)
+		(when (not= w.lines_excess_match_id nil)
+			(pcall #(call.matchdelete w.lines_excess_match_id)))
+		(execute-if-writable-buffer (fn []
+			(local textwidth (opt.textwidth:get))
+			(when (> textwidth 0)
+				(local regex (string.format "\\%%>%iv.\\+" textwidth))
+				(set w.lines_excess_match_id (call.matchadd :ColorColumn regex -1)))))))
 
 (local trailing-whitespace-regex (string.format
 	"[%s]\\+\\%%#\\@<!$"
@@ -47,25 +48,27 @@
 		:\ufeff] ""))) ; zero width non-breaking space
 
 (fn highlight-trailing-whitespace []
-	(when (not= w.trailing_whitespace_match_id nil)
-		(pcall #(call.matchdelete w.trailing_whitespace_match_id)))
-	(execute-if-writable-buffer (fn []
-		(set w.trailing_whitespace_match_id
-			(call.matchadd :ColorColumn trailing-whitespace-regex)))))
+	(when (not vim.b.Snitch_disable_trailing_whitespace)
+		(when (not= w.trailing_whitespace_match_id nil)
+			(pcall #(call.matchdelete w.trailing_whitespace_match_id)))
+		(execute-if-writable-buffer (fn []
+			(set w.trailing_whitespace_match_id
+				(call.matchadd :ColorColumn trailing-whitespace-regex))))))
 
 (local spaces-indentation "^\\ \\ *")
 (local tabs-indentation "^\\t\\t*")
 (fn highlight-wrong-indentation []
-	(when (not= w.wrong_indentation_match_id nil)
-		(pcall #(call.matchdelete w.wrong_indentation_match_id)))
-	(execute-if-writable-buffer (fn []
-		(local wrong-indentation-regex
-			(if (opt.expandtab:get) tabs-indentation
-				(if (or (= (opt.softtabstop:get) 0) (= (opt.softtabstop:get) (opt.tabstop:get)))
-					(.. spaces-indentation "\\|" tabs-indentation "\\zs\\ \\+")
-					spaces-indentation)))
-		(set w.wrong_indentation_match_id
-			(call.matchadd :ColorColumn wrong-indentation-regex)))))
+	(when (not vim.b.Snitch_disable_wrong_indentation)
+		(when (not= w.wrong_indentation_match_id nil)
+			(pcall #(call.matchdelete w.wrong_indentation_match_id)))
+		(execute-if-writable-buffer (fn []
+			(local wrong-indentation-regex
+				(if (opt.expandtab:get) tabs-indentation
+					(if (or (= (opt.softtabstop:get) 0) (= (opt.softtabstop:get) (opt.tabstop:get)))
+						(.. spaces-indentation "\\|" tabs-indentation "\\zs\\ \\+")
+						spaces-indentation)))
+			(set w.wrong_indentation_match_id
+				(call.matchadd :ColorColumn wrong-indentation-regex))))))
 
 (global Snitch {})
 (set Snitch.highlight_lines_excess highlight-lines-excess)

--- a/plugin/snitch.lua
+++ b/plugin/snitch.lua
@@ -1,68 +1,86 @@
-local _2afile_2a = "plugin/snitch.fnl"
 local call = vim.fn
 local opt = vim.opt
 local w = vim.w
 local function execute_if_writable_buffer(procedure)
-  local buftype = (opt.buftype):get()
+  local buftype = opt.buftype:get()
   if ((buftype == "") or (buftype == "acwrite")) then
     return procedure()
+  else
+    return nil
   end
 end
 local function highlight_lines_excess()
-  if (w.lines_excess_match_id ~= nil) then
-    local function _1_()
-      return call.matchdelete(w.lines_excess_match_id)
+  if not vim.b.Snitch_disable_lines_excess then
+    if (w.lines_excess_match_id ~= nil) then
+      local function _2_()
+        return call.matchdelete(w.lines_excess_match_id)
+      end
+      pcall(_2_)
+    else
     end
-    pcall(_1_)
-  end
-  local function _2_()
-    local textwidth = (opt.textwidth):get()
-    if (textwidth > 0) then
-      local regex = string.format("\\%%>%iv.\\+", textwidth)
-      w.lines_excess_match_id = call.matchadd("ColorColumn", regex, -1)
-      return nil
+    local function _4_()
+      local textwidth = opt.textwidth:get()
+      if (textwidth > 0) then
+        local regex = string.format("\\%%>%iv.\\+", textwidth)
+        w.lines_excess_match_id = call.matchadd("ColorColumn", regex, -1)
+        return nil
+      else
+        return nil
+      end
     end
+    return execute_if_writable_buffer(_4_)
+  else
+    return nil
   end
-  return execute_if_writable_buffer(_2_)
 end
 local trailing_whitespace_regex = string.format("[%s]\\+\\%%#\\@<!$", call.join({"\\u0009", "\\u0020", "\\u00a0", "\\u1680", "\\u2000", "\\u2001", "\\u2002", "\\u2003", "\\u2004", "\\u2005", "\\u2006", "\\u2007", "\\u2008", "\\u2009", "\\u200a", "\\u202f", "\\u205f", "\\u3000", "\\u180e", "\\u200b", "\\u200c", "\\u200d", "\\u2060", "\\ufeff"}, ""))
 local function highlight_trailing_whitespace()
-  if (w.trailing_whitespace_match_id ~= nil) then
-    local function _1_()
-      return call.matchdelete(w.trailing_whitespace_match_id)
+  if not vim.b.Snitch_disable_trailing_whitespace then
+    if (w.trailing_whitespace_match_id ~= nil) then
+      local function _7_()
+        return call.matchdelete(w.trailing_whitespace_match_id)
+      end
+      pcall(_7_)
+    else
     end
-    pcall(_1_)
-  end
-  local function _2_()
-    w.trailing_whitespace_match_id = call.matchadd("ColorColumn", trailing_whitespace_regex)
+    local function _9_()
+      w.trailing_whitespace_match_id = call.matchadd("ColorColumn", trailing_whitespace_regex)
+      return nil
+    end
+    return execute_if_writable_buffer(_9_)
+  else
     return nil
   end
-  return execute_if_writable_buffer(_2_)
 end
 local spaces_indentation = "^\\ \\ *"
 local tabs_indentation = "^\\t\\t*"
 local function highlight_wrong_indentation()
-  if (w.wrong_indentation_match_id ~= nil) then
-    local function _1_()
-      return call.matchdelete(w.wrong_indentation_match_id)
-    end
-    pcall(_1_)
-  end
-  local function _2_()
-    local wrong_indentation_regex
-    if (opt.expandtab):get() then
-      wrong_indentation_regex = tabs_indentation
-    else
-      if (((opt.softtabstop):get() == 0) or ((opt.softtabstop):get() == (opt.tabstop):get())) then
-        wrong_indentation_regex = (spaces_indentation .. "\\|" .. tabs_indentation .. "\\zs\\ \\+")
-      else
-        wrong_indentation_regex = spaces_indentation
+  if not vim.b.Snitch_disable_wrong_indentation then
+    if (w.wrong_indentation_match_id ~= nil) then
+      local function _11_()
+        return call.matchdelete(w.wrong_indentation_match_id)
       end
+      pcall(_11_)
+    else
     end
-    w.wrong_indentation_match_id = call.matchadd("ColorColumn", wrong_indentation_regex)
+    local function _13_()
+      local wrong_indentation_regex
+      if opt.expandtab:get() then
+        wrong_indentation_regex = tabs_indentation
+      else
+        if ((opt.softtabstop:get() == 0) or (opt.softtabstop:get() == opt.tabstop:get())) then
+          wrong_indentation_regex = (spaces_indentation .. "\\|" .. tabs_indentation .. "\\zs\\ \\+")
+        else
+          wrong_indentation_regex = spaces_indentation
+        end
+      end
+      w.wrong_indentation_match_id = call.matchadd("ColorColumn", wrong_indentation_regex)
+      return nil
+    end
+    return execute_if_writable_buffer(_13_)
+  else
     return nil
   end
-  return execute_if_writable_buffer(_2_)
 end
 Snitch = {}
 Snitch.highlight_lines_excess = highlight_lines_excess


### PR DESCRIPTION
Recent versions of tools surrounding Rust and the rust-analyzer have switched from using inlay text only after all code, to interlacing inlay text with actual file code. This causes code that would otherwise be less than `&textwidth` characters wide to be displayed past the margin.

![image](https://github.com/user-attachments/assets/f02d895a-35d1-48ba-a0d9-bdce79fa2e43)

In addition to causing well-behaved formatting to appear badly formatted, the inlay highlight also seems to conflict with the snitch highlighting.

In order to continue using the other two features of nvim-snitch, this PR implements 3 buffer-specific flags to individually disable the features. All three features are enabled by default and are disabled by setting the corresponding flag to `v:true`.

This enables disabling specific features on a per-buffer basis, or per filetype using an autocmd like the following:

```lua
vim.api.nvim_create_autocmd('FileType', {
  pattern = 'rust',
  command = 'let b:Snitch_disable_lines_excess = v:true',
})
```